### PR TITLE
Fix Large Mempool Allocation Failures

### DIFF
--- a/src/mempool.c
+++ b/src/mempool.c
@@ -113,20 +113,20 @@ void* mempool_Alloc(struct mempool* pool, size_t size)
 	int blocksNeeded, bitsRem, bit;
 	unsigned long mask;
 
-    if(size <= 1) size = (1 << MEMPOOL_QUANTUM_POWER);
+    if(size <= 1) size = ((size_t)1 << MEMPOOL_QUANTUM_POWER);
     blocksNeeded = (int)MEMPOOL_QUANTUMS(size);
 
 	if(blocksNeeded > MEMPOOL_BLOCK_QUANTUMS) {
 		return malloc(MEMPOOL_BLOCK_QUANTIFY(size));
 	}
 
-	mask = (1 << blocksNeeded) - 1;
+	mask = ((unsigned long)1 << blocksNeeded) - 1;
 
 	bitsRem = MEMPOOL_BLOCK_QUANTUMS - blocksNeeded;
 	for(bit = 0; bit <= bitsRem; ++bit) {
 		if(((pool->bitmask >> bit) & mask) == 0) {
 			pool->bitmask |= mask << bit;
-			void* pd = pool->data + (1 << MEMPOOL_QUANTUM_POWER) * bit;
+			void* pd = pool->data + ((unsigned long)1 << MEMPOOL_QUANTUM_POWER) * bit;
 			return pd;
 		}
 	}
@@ -147,7 +147,7 @@ void mempool_Free(struct mempool* pool, void* ptr, size_t size)
 	if(p >= pool->data && p < end) {
 		int blocksNeeded, offset;
     	size_t mask;
-    	if(size <= 1) size = (1 << MEMPOOL_QUANTUM_POWER);
+    	if(size <= 1) size = ((size_t)1 << MEMPOOL_QUANTUM_POWER);
 	    blocksNeeded = (int)((size - 1) >> (MEMPOOL_QUANTUM_POWER)) + 1;
 		offset = (int)((p - pool->data) >> MEMPOOL_QUANTUM_POWER);
 		mask = MEMPOOL_BITMASK(blocksNeeded, offset);
@@ -169,8 +169,8 @@ static unsigned char* mempool_ReAlloc_internal(struct mempool* pool, struct memp
 		void* newptr;
 		int oldNeeded, newNeeded, offset;
 		
-	    if(oldSize <= 1) oldSize = (1 << MEMPOOL_QUANTUM_POWER);
-    	if(newSize <= 1) newSize = (1 << MEMPOOL_QUANTUM_POWER);
+	    if(oldSize <= 1) oldSize = ((size_t)1 << MEMPOOL_QUANTUM_POWER);
+    	if(newSize <= 1) newSize = ((size_t)1 << MEMPOOL_QUANTUM_POWER);
 	    oldNeeded = (int)MEMPOOL_QUANTUMS(oldSize);
     	newNeeded = (int)MEMPOOL_QUANTUMS(newSize);
 	    if(newNeeded <= oldNeeded) return ptr; /* Never shrink */

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -117,10 +117,17 @@ void* mempool_Alloc(struct mempool* pool, size_t size)
     blocksNeeded = (int)MEMPOOL_QUANTUMS(size);
 
 	if(blocksNeeded > MEMPOOL_BLOCK_QUANTUMS) {
+        // Number of blocks required to store `size` exceeds the amount
+        // that will fit within a block.
 		return malloc(MEMPOOL_BLOCK_QUANTIFY(size));
-	}
-
-	mask = ((unsigned long)1 << blocksNeeded) - 1;
+	} else if (blocksNeeded == MEMPOOL_BLOCK_QUANTUMS) {
+        // Storing `size` requires an entire block.
+        // Doing a left-shift of `blocksNeeded` will overflow, so we
+        // manually set the `mask` to cover the entire block (0xFFFF...FFFF).
+        mask = ~(unsigned long)0;
+    } else {
+        mask = ((unsigned long)1 << blocksNeeded) - 1;
+    }
 
 	bitsRem = MEMPOOL_BLOCK_QUANTUMS - blocksNeeded;
 	for(bit = 0; bit <= bitsRem; ++bit) {


### PR DESCRIPTION
@rickardp 

This addresses some edge-cases I ran into using the mempool when allocating large swaths of memory on a 64-bit system.

 1. a002d91: Perform left-shifts using an integer type large enough to store shifting to their maximum possible value. The main issue was in `mempool_Alloc()`, where `mask` would be computed incorrectly if `blocksNeeded > 32`.
 2. 2891b13: When allocating a size which required 64 blocks, the `mask` computation would overflow, and the resulting `mask` would be zero. This would overwrite data already in the block.

## a002d91 - Left-Shift Casting

When a `1` is left-shifted, some compilers seem to select an integer type which may not be large enough for the resulting shift. Example with gcc-6.3.0:

```c
#include <stdint.h>
#include <stdio.h>

int main(int argc, char ** argv) {
    int blocksNeeded = 57;
    uint64_t mask_without_casting = (1 << blocksNeeded) - 1;
    uint64_t mask_with_casting = ((uint64_t)1 << blocksNeeded) - 1;

    printf("Mask w/o casting for 57 blocks [original]: %016lx\n", mask_without_casting);
    printf("Mask w/  casting for 57 blocks [new]:      %016lx\n", mask_with_casting);
    return 0;
}
```

This produces the following:
```
$ gcc junk.c && ./a.out
Mask w/o casting for 57 blocks [original]: 0000000001ffffff
Mask w/  casting for 57 blocks [new]:      01ffffffffffffff
```

This would result in an incorrect mask when adding values that needed 32 blocks or more. I changed all left-shifts to cast the number being shifted to the LHS type (either `unsigned long` or `size_t`).

## 2891b13 - Storing data consuming 64 blocks
When `mempool_Alloc()` is called with a `size` requiring 64 blocks, the `mask` computation overflows and produces a mask of `0x00`. Example:
```
#include <stdint.h>
#include <stdio.h>

int main(int argc, char ** argv) {
    int blocksNeeded = 64;
    uint64_t mask = ((uint64_t)1 << blocksNeeded) - 1;

    printf("Mask for 64 blocks: %016lx\n", mask);
    return 0;
}
```

This produces the following:
```
Mask for 64 blocks: 0000000000000000
```

The _correct_ mask for 64 bytes should actually be `0xFFFFFFFFFFFFFFFF`. I changed the `mempool_Alloc()` to handle this case special case.

Thanks for looking at this PR! :smiley: 