### PR TITLE
Only discard document buffer exceeding length when entire buffer is scanned

### DIFF
--- a/src/splitstream.c
+++ b/src/splitstream.c
@@ -64,8 +64,10 @@ SplitstreamDocument SPLITSTREAM_API SplitstreamGetNextDocument(SplitstreamState*
     if(s->state != State_Init && start < len) {
         if(didSetStart) {
             SplitstreamDocumentFree(s, &s->doc);
-        } else if(s->doc.length + len - start > max) {
-            // If document was too large, discard it
+        } else if(end == 0 &&  // No document was found.
+                  s->doc.length + len - start > max) {
+            // If we scanned more than `max` without finishing a document,
+            // discard what we have read so far and start over.
             SplitstreamDocumentFree(s, &s->doc);
             s->state = State_Init;
         }


### PR DESCRIPTION
@rickardp 

Fixes a bug where the scan/in-progress-document buffer could be discarded if the _buffer_ ever exceeded the max document size. If a document was found by `scan()` (i.e., `end > 0`), then we should not discard the in-progress document (`s->doc`), because whatever remained in `s->doc` was _not_ scanned, so we don't know if it contains a document (of valid length). This can happen if `bufsize` is much larger than `maxdocsize`, because a huge amount of data will be read out of the file (causing the amount of data left in the buffer after a scan to exceed the max document size).