### PR TITLE
Fix compilation issue on Visual C

### DIFF
--- a/src/python/splitstream_py.c
+++ b/src/python/splitstream_py.c
@@ -103,7 +103,7 @@ static PyObject* splitfile(PyObject* self, PyObject* args, PyObject* kwargs)
     Generator* g;
     static int gt = 0;
     static PyTypeObject gentype = {
-    	PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    	PyVarObject_HEAD_INIT(NULL, 0)
     	"splitstream.( generator )",
     	sizeof(Generator)
     };


### PR DESCRIPTION
This fixes the 
`src/python/splitstream_py.c(106): error C2099: initializer is not a constant`
error when compiling wth Visual C 2019 (14.2) on Windows