### PR TITLE
Add support for Windows

### DIFF
--- a/src/python/splitstream_py.c
+++ b/src/python/splitstream_py.c
@@ -103,7 +103,7 @@ static PyObject* splitfile(PyObject* self, PyObject* args, PyObject* kwargs)
     Generator* g;
     static int gt = 0;
     static PyTypeObject gentype = {
-    	PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    	PyVarObject_HEAD_INIT(NULL, 0)
     	"splitstream.( generator )",
     	sizeof(Generator)
     };


### PR DESCRIPTION
Build error in Windows is caused by `&PyType_Type` which is a `PyObject*` as the type of a type object is
'type', but this isn’t strictly conforming C and some compilers, e.g Visual C and MinGW's gcc, complain.

So we change:

https://github.com/rickardp/splitstream/blob/6f188a96f6dff02643029b4c8ddd771effd91aa7/src/python/splitstream_py.c#L106

to:

PyVarObject_HEAD_INIT(NULL, 0)

Fortunately, this member will be filled in for us by `PyType_Ready()` making everything work.

Tested on Windows and Ubuntu.